### PR TITLE
Add ability to build scudo-free 32-bit libc variant.

### DIFF
--- a/android/variable.go
+++ b/android/variable.go
@@ -55,6 +55,13 @@ type variableProperties struct {
 			Exclude_static_libs []string `android:"arch_variant"`
 		} `android:"arch_variant"`
 
+		Malloc_not_svelte_libc32 struct {
+			Cflags              []string `android:"arch_variant"`
+			Shared_libs         []string `android:"arch_variant"`
+			Whole_static_libs   []string `android:"arch_variant"`
+			Exclude_static_libs []string `android:"arch_variant"`
+		} `android:"arch_variant"`
+
 		Malloc_zero_contents struct {
 			Cflags []string `android:"arch_variant"`
 		} `android:"arch_variant"`
@@ -229,6 +236,7 @@ type productVariables struct {
 	Always_use_prebuilt_sdks     *bool `json:",omitempty"`
 	Skip_boot_jars_check         *bool `json:",omitempty"`
 	Malloc_not_svelte            *bool `json:",omitempty"`
+	Malloc_not_svelte_libc32         *bool `json:",omitempty"`
 	Malloc_zero_contents         *bool `json:",omitempty"`
 	Malloc_pattern_fill_contents *bool `json:",omitempty"`
 	Safestack                    *bool `json:",omitempty"`
@@ -440,6 +448,7 @@ func (v *productVariables) SetDefaultConfig() {
 		AAPTPrebuiltDPI:     []string{"xhdpi", "xxhdpi"},
 
 		Malloc_not_svelte:            boolPtr(true),
+		Malloc_not_svelte_libc32:     boolPtr(true),
 		Malloc_zero_contents:         boolPtr(true),
 		Malloc_pattern_fill_contents: boolPtr(false),
 		Safestack:                    boolPtr(false),


### PR DESCRIPTION
The default value is set to enable scudo with the
32-bit libc variant.

This fixes camera not working on some legacy devices.

https://review.lineageos.org/c/LineageOS/android_build_soong/+/322578