### PR TITLE
Revert LTO related changes [SQUASH]

### DIFF
--- a/cc/lto.go
+++ b/cc/lto.go
@@ -109,8 +109,12 @@ func (lto *lto) flags(ctx ModuleContext, flags Flags) Flags {
 		ltoCFlags := []string{"-flto=thin", "-fsplit-lto-unit"}
 		var ltoLdFlags []string
 
-		// Do not perform costly LTO optimizations for Eng builds.
-		if Bool(lto.Properties.Lto_O0) || ctx.Config().Eng() {
+		// The module did not explicitly turn on LTO. Only leverage LTO's
+		// better dead code elimination and CFG simplification, but do
+		// not perform costly optimizations for a balance between compile
+		// time, binary size and performance.
+		// Apply the same for Eng builds as well.
+		if !lto.ThinLTO() || ctx.Config().Eng() {
 			ltoLdFlags = append(ltoLdFlags, "-Wl,--lto-O0")
 		}
 


### PR DESCRIPTION
reason for revert: two devices reported dead fingerprint (sunfish, marble) - this issue arised when were messing with lto particularly with experimental patches: b24d210bfc55a5173323e787d0f9f379f098c244 and 258e67bbc907c66c2fb439838137575401b91a0e

* possible culprit for fingeprint module breakages

Revert "lto: enable O3 optimizations on explicit lto modules"

This reverts commit 79163e3ce1c9fdcdd762c14aa8a4183a74d9147d.

Revert "cc: enable Polly globally"

This reverts commit 8c0bc52e7dfd1205e529e5d873656676d18ff547.

Revert "Enable full LTO optimization by default"

This reverts commit 6e60ff8df04fded1ac2b47ff85896cfa3f4619bb.

test: confirmed that fingerprint is now working on marble after reverting lto-related patches