### PR TITLE
Soong: Add camera Extensions to whitelist

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -310,3 +310,7 @@ org\.ifaa\.aidl.*
 ###################################################
 # Camera Extensions
 com.camera.camera2.extensions.*
+
+###################################################
+# Xiaomi Extensions
+com.xiaomi.extensions.*

--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -306,3 +306,7 @@ qcom.fmradio
 # IFAA Manager used for Alipay and/or WeChat payment
 org\.ifaa\.android\.manager.*
 org\.ifaa\.aidl.*
+
+###################################################
+# Camera Extensions
+com.camera.camera2.extensions.*


### PR DESCRIPTION
If we are trying to include camerax-vendor-extensions.jar from Miui/HyperOS as BootJar, while compilation buildsystem provides with error that the following packages needs to be whitelisted

After adding the following packages, compliation completes without issues, boots successfully.