### PR TITLE
soong: Allow com.thundersoft package on bootclasspath

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -290,6 +290,7 @@ net.oneplus.*
 oplus.*
 vendor.oplus.*
 com.oneplus.*
+com\.thundersoft\..*
 vendor.oneplus.*
 
 # LMOFreeform


### PR DESCRIPTION
The oplus-fwk library includes a stub for
com.thundersoft.security.ContainerManager, which is referenced by OnePlus Gallery. Add the package prefix to the boot JAR allowed list.