### PR TITLE
soong: Increase ThinLTO cache to 15GB

### DIFF
--- a/cc/lto.go
+++ b/cc/lto.go
@@ -140,9 +140,9 @@ func (lto *lto) flags(ctx ModuleContext, flags Flags) Flags {
 			ltoLdFlags = append(ltoLdFlags, cacheDirFormat+cacheDir)
 
 			// Limit the size of the ThinLTO cache to the lesser of 10% of available
-			// disk space and 10GB.
+			// disk space and 15GB.
 			cachePolicyFormat := "-Wl,--thinlto-cache-policy="
-			policy := "cache_size=10%:cache_size_bytes=10g"
+			policy := "cache_size=10%:cache_size_bytes=15g"
 			ltoLdFlags = append(ltoLdFlags, cachePolicyFormat+policy)
 		}
 


### PR DESCRIPTION
Increase the ThinLTO cache limit to 15GB to prevent it from emptying prematurely.

LLVM ERROR: Failed to rename temporary file out/soong/thinlto-cache/Thin-d6dd2b.tmp.o
to out/soong/thinlto-cache/llvmcache-80A2C642488B764B54107C1A69424152F1D3AD01: No such file or directory